### PR TITLE
Simplify nokogiri dependency

### DIFF
--- a/smart_proxy_omaha.gemspec
+++ b/smart_proxy_omaha.gemspec
@@ -14,13 +14,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/theforeman/smart_proxy_omaha'
   s.license = 'GPLv3'
 
-  if RUBY_VERSION < '1.9'
-    s.add_dependency('nokogiri', '<= 1.5.11')
-  elsif RUBY_VERSION < '2.1'
-    s.add_dependency('nokogiri', '>= 1.5.11')
-  else
-    s.add_dependency('nokogiri', '>= 1.8.1')
-  end
+  s.add_dependency('nokogiri', '>= 1.5.11')
   s.add_dependency('json')
 
   s.add_development_dependency('test-unit', '~> 2')


### PR DESCRIPTION
gemspecs don't actually support conditional ruby version support. It is
evaluated on gem build by the ruby version you are then using. Since we
still support nokogiri 1.5.11 we should use that dependency.