### PR TITLE
Fix/flatcar sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ For CoreOS:
 
 For Flatcar:
 * www.flatcar-linux.org
+* www.flatcar.org
 * alpha.release.flatcar-linux.net
 * beta.release.flatcar-linux.net
 * stable.release.flatcar-linux.net

--- a/extra/foreman-proxy-omaha-sync.cron
+++ b/extra/foreman-proxy-omaha-sync.cron
@@ -1,2 +1,2 @@
 # Sync omaha releases once a day
-0 22 * * * foreman-proxy smart-proxy-omaha-sync >>/var/log/foreman-proxy/cron.log 2>&1
+0 22 * * * foreman-proxy source /opt/theforeman/tfm/enable; smart-proxy-omaha-sync >>/var/log/foreman-proxy/cron.log 2>&1

--- a/lib/smart_proxy_omaha/distribution.rb
+++ b/lib/smart_proxy_omaha/distribution.rb
@@ -72,7 +72,7 @@ module Proxy
         end
 
         def releases(track, architecture)
-          feed_data = http_request.get("https://www.flatcar-linux.org/releases-json/releases-#{track}.json")
+          feed_data = http_request.get("https://www.flatcar.org/releases-json/releases-#{track}.json")
           json_feed = JSON.parse(feed_data)
           json_feed.select { |_, release| release['architectures'].include?(architecture.split('-').first) }.keys - ['current']
         end

--- a/lib/smart_proxy_omaha/http_request.rb
+++ b/lib/smart_proxy_omaha/http_request.rb
@@ -6,10 +6,8 @@ module Proxy::Omaha
     include HttpShared
 
     def get(url)
-      http, request = connection_factory(url)
-
       Timeout::timeout(10) do
-        response = http.request(request)
+        response = get_recursive(url)
 
         raise "Error retrieving from #{url}: #{response.class}" unless ["200", "201"].include?(response.code)
 
@@ -18,10 +16,8 @@ module Proxy::Omaha
     end
 
     def head(url)
-      http, request = connection_factory(url, :method => :head)
-
       Timeout::timeout(10) do
-        response = http.request(request)
+        response = get_recursive(url, opts = {:method => :head})
 
         raise "Error retrieving from #{url}: #{response.class}" unless ["200", "201"].include?(response.code)
 

--- a/lib/smart_proxy_omaha/http_shared.rb
+++ b/lib/smart_proxy_omaha/http_shared.rb
@@ -35,5 +35,13 @@ module Proxy::Omaha
 
       [http, request]
     end
+
+    def get_recursive(url, opts = {}, limit = 10)
+      http, request = connection_factory(url, opts)
+      response = http.request(request)
+      response = get_recursive(response['location'], opts, limit - 1) if response.code == '302'
+
+      response
+    end
   end
 end

--- a/test/omaha/release_provider_test.rb
+++ b/test/omaha/release_provider_test.rb
@@ -69,7 +69,7 @@ class ReleaseProviderTest < Test::Unit::TestCase
       distribution: distribution
     )
 
-    stub_request(:get, 'https://www.flatcar-linux.org/releases-json/releases-stable.json')
+    stub_request(:get, 'https://www.flatcar.org/releases-json/releases-stable.json')
       .to_return(status: [200, 'OK'], body: fixture('flatcar_releases-stable.json'))
 
     expected = ['1688.5.3', '1745.3.1', '1745.4.0', '1745.5.0', '1745.6.0', '1745.7.0', '1800.4.0', '1800.5.0', '1800.6.0', '1800.7.0', '1855.4.0', '1855.4.2', '1855.5.0', '1911.3.0', '1911.4.0', '1911.5.0', '1967.3.0', '1967.3.1', '1967.4.0', '1967.5.0', '1967.6.0', '2023.4.0', '2023.5.0', '2079.3.0', '2079.3.1', '2079.3.2', '2079.4.0', '2079.5.0', '2079.6.0', '2135.4.0', '2135.5.0', '2135.6.0', '2191.4.0', '2191.4.1', '2191.5.0', '2247.5.0', '2247.6.0', '2247.7.0', '2303.3.0', '2303.3.1', '2303.4.0', '2345.3.0']


### PR DESCRIPTION
- Use SCL in sync cronjob. This is needed due to https://github.com/theforeman/foreman-packaging/commit/c65291f274228eeb0bea96e388062e556ee38c32#diff-0e3b087fb664009f7f5dcc3858aec8f659bdc45b0a6a42be7d4f781ac31646ad 
- Support fetching URLs recursively if we get a HTTP 302 code